### PR TITLE
Various small fixes

### DIFF
--- a/src/components/DataLayersCard.vue
+++ b/src/components/DataLayersCard.vue
@@ -40,7 +40,7 @@
                   cols="7"
                   class="ma-auto pa-0"
                 >
-                  <span class="ml-2 d-sm-none d-md-flex">{{ dataset.title }}</span> 
+                  <span class="ml-2 d-sm-none d-md-flex">{{ dataset.name }}</span> 
                 </v-col>
                 <v-col
                   cols="2"
@@ -107,7 +107,7 @@
                     :label="summary.id"
                     flat
                     dense
-                    @change="toggleMapboxLayer(dataset)"
+                    @change="toggleLocationDataset(dataset)"
                   />          
                 </v-col>
               </v-row>
@@ -141,48 +141,20 @@
     methods: {
       ...mapActions ([ 'loadLocationDataset','clearActiveDatasetIds' ]),
       toggleLocationDataset(dataset) {
-        const { id } = dataset
-        let oldParams = _.get(this.$route, 'params.datasetIds')
-        const params = this.$route.params
-        let newParams 
 
-        if (!oldParams) {
-          //if oldPrams is undefined, set newParams by id
-          newParams = id
-        }else {
-          // Else check if new id should be removed or added to new route
-          oldParams = oldParams.split(',')
-          if (oldParams.includes(id)) {
-            // if oldparams already includes id, remove from route
-            newParams = oldParams.filter(param => param !== id)
-            if (newParams.length === 0) {
-              newParams = undefined
-            } else {
-              newParams = newParams.join(',')
-            }
-          } else {
-            // else add id to route and zoomtobbox
-            newParams = `${oldParams},${id}`
-          }
-        }
-        params.datasetIds = newParams
+        // Removed code to add multiple params in route, as this did not work anymore
+        const { id } = dataset
+        const params = this.$route.params
+        params.datasetIds = id
         let path = `/data/${params.datasetIds}`
         if (_.has(params, 'locationId')) {
           path = `/data/${params.datasetIds}/${params.locationId}`
         }
-        if (newParams) {
-          this.$router.push({ path, params })
-        } else {
-          this.$router.push('/data')
-        }
-
         //find the layer of the dataset to load on the map based on the chosen values only if the dataset is visible
         if (!dataset.visible) {
           this.clearActiveDatasetIds()
           return
         }
-       
-        
         this.loadLocationDataset(dataset)
       },
 

--- a/src/components/DataLayersCard.vue
+++ b/src/components/DataLayersCard.vue
@@ -40,7 +40,7 @@
                   cols="7"
                   class="ma-auto pa-0"
                 >
-                  <span class="ml-2 d-sm-none d-md-flex">{{ dataset.name }}</span> 
+                  <span class="ml-2 d-sm-none d-md-flex">{{ dataset.id }}</span> 
                 </v-col>
                 <v-col
                   cols="2"

--- a/src/store/map/index.js
+++ b/src/store/map/index.js
@@ -68,10 +68,6 @@ export default {
         return children.forEach(child => {
           return getCatalog(child.href)
             .then(dataset => {
-              // TODO: Extra Storm Surge Level is the template layer, filter this out!
-              if (child.title === 'Extra Storm Surge Level') {
-                return
-              }
               //All the below functionality will be added in a function at the end
               const summaries = _.get(dataset, 'summaries')
               const mappedSummaries = Object.keys(summaries).map(id => {
@@ -112,6 +108,8 @@ export default {
         return
       }
       const url = _.get(dataset, 'assets.data.href')
+      // const datasetName = "replace"
+      const datasetName = _.get(dataset, 'name')
       const path = Object.keys(_.get(dataset, 'cube:variables'))[0]
       const dimensions = Object.entries(_.get(dataset, `["cube:variables"].${path}.dimensions`))
       const variableUnit = Object.entries(_.get(dataset, `["cube:variables"].${path}.unit`))
@@ -138,17 +136,21 @@ export default {
                 data: Array.from(serie)
               }
             })
-
             // TODO: Which axis belongs to which dimension????
             let cubeDimensions = _.get(dataset, 'cube:dimensions')
             // cubeDimensions = cubeDimensions.filter(dim => dim.type === 'temporal')
             const xAxis = Object.keys(cubeDimensions)[2]
             const yAxis = variableUnit[0][1]
-            for (var i = 0; i < cubeDimensions.scenario.values.length; i++) {
-              series[i].name = cubeDimensions.scenario.values[i]
+            // Name based on properties.deltares:plotSeries from STAC
+            const plotSeries = _.get(dataset, 'properties.deltares:plotSeries')
+            const dimensionNames = Object.entries(_.get(dataset, `["cube:dimensions"].${plotSeries}.values`))
+
+            for (var i = 0; i < dimensionNames.length; i++) {
+              series[i].name = dimensionNames[i][1]
             }
             commit('addDatasetPointData', {
               id: datasetId,
+              name: datasetName,
               series,
               xAxis: {
                 type: 'category',
@@ -182,7 +184,6 @@ export default {
       }
       }
       const layer = links.find(filterByProperty)
-
       if (!layer) {
           return
       }

--- a/src/views/DataLayers.vue
+++ b/src/views/DataLayers.vue
@@ -4,6 +4,8 @@
     <mapbox-map
       slot="map"
       :access-token="accessToken"
+      :center="[5.2913, 48.1326]"
+      :zoom="4"
       mapbox-style="mapbox://styles/global-data-viewer/cjtslsula05as1fppvrh7n4rv"
       @load="initializeMap"
     >
@@ -52,7 +54,8 @@
           'circle-stroke-opacity': 0.8
         }
       },
-      map: {}
+      map: {},
+      mapLoaded: true,
     }),
     components: {
       DataLayersCard,

--- a/src/views/data/locations/LocationIds.vue
+++ b/src/views/data/locations/LocationIds.vue
@@ -38,7 +38,7 @@
               color="background"
               dark
             >
-              {{ data.name }}
+              {{ data.id }}
             </v-expansion-panel-header>
             <v-expansion-panel-content color="background">
               <v-container class="pa-0">

--- a/src/views/data/locations/LocationIds.vue
+++ b/src/views/data/locations/LocationIds.vue
@@ -38,7 +38,7 @@
               color="background"
               dark
             >
-              {{ data.id }}
+              {{ data.name }}
             </v-expansion-panel-header>
             <v-expansion-panel-content color="background">
               <v-container class="pa-0">
@@ -253,7 +253,8 @@
     },
     mounted () {
       this.loadPointDataForLocation()
-      this.expandedDatasets = [...Array(this.datasets.length).keys()]
+      // Added +1 to ensure that this also opens when length = 0
+      this.expandedDatasets = [...Array(this.datasets.length+1).keys()]
     },
     methods: {
       ...mapActions([ 'storeActiveDatasetIds', 'loadPointDataForLocation' ]),


### PR DESCRIPTION
- Changes default zoom level and center
- Removed some old BlueEarth Data code from DataLayersCard.vue which was used to combine data from multiple dataset in one plot. This did not work in the present implementation yet, and caused issues showing the timeseries.
- In index.js, we were referring to "cubeDimensions.scenario". Since the wave energy flux did not have a scenario dimension, this had to be generalized. The appropriate variable to use here now is defined in the STAC catalog by  'properties.deltares:plotSeries'. (These fields been implemented in the main/live STAC branch already.)
- DataLayersCard.vue was referring to toggleMapboxLayer function, which I think should be toggleLocationDataset instead.
- Fix in LocationsId.vue required to visualize the timeseries properly. Index in this.expandedDatasets = etc was causing problems. With this change it worked.
- Busy adding field with more descriptive dataset name in STAC catalog, to be used to dataset panel and in header of timeseries plot (for example, Sea surface level instead of ssl). But change not in present main/live STAC yet, so rolled back, and still referring to .id rather than .name.