### PR TITLE
Show legend only when properties.deltares:linearGradient exists in STAC catalog

### DIFF
--- a/src/components/DataLayersCard.vue
+++ b/src/components/DataLayersCard.vue
@@ -134,7 +134,7 @@
                   />
                 </v-col>
               </v-row>
-              <v-row v-if="dataset.id === activeLocationDatasetId">
+              <v-row v-if="dataset.id === activeLocationDatasetId && activeLegend(dataset) === true">
                 <v-col>
                   <layer-legend :dataset="dataset" />
                 </v-col>
@@ -226,6 +226,10 @@
         //Assumption: if layer has cube:dimensions then it is a vector
         //TODO: add in the stacCatalogue structure a format parameter somehow
         return _.has(dataset, 'cube:dimensions') ? 'vector' : 'raster'
+      },
+      activeLegend (dataset) {
+        // Check if linearGradient is defined. If so, assume that legend has to be shown
+        return _.has(dataset, 'properties.deltares:linearGradient') ? true : false
       }
     }
   }

--- a/src/components/DataLayersCard.vue
+++ b/src/components/DataLayersCard.vue
@@ -134,7 +134,7 @@
                   />
                 </v-col>
               </v-row>
-              <v-row v-if="dataset.id === activeLocationDatasetId && activeLegend(dataset) === true">
+              <v-row v-if="dataset.id === activeLocationDatasetId && activeLegend(dataset)">
                 <v-col>
                   <layer-legend :dataset="dataset" />
                 </v-col>

--- a/src/components/DataLayersCard.vue
+++ b/src/components/DataLayersCard.vue
@@ -229,7 +229,7 @@
       },
       activeLegend (dataset) {
         // Check if linearGradient is defined. If so, assume that legend has to be shown
-        return _.has(dataset, 'properties.deltares:linearGradient') ? true : false
+        return _.has(dataset, 'properties.deltares:linearGradient')
       }
     }
   }


### PR DESCRIPTION
The legend was also shows for the polygon layer ("Adaptation"), where it has no meaning. As such, added some logic so that the legend is only shown if properties.deltares:linearGradient exists in the STAC catalog. In that case, if we remove this section of the catalog for the "Adaptation" dataset, the legend will not be shown.

(Only a small change, but figured it would still be good to create a branch and pr)