### PR TITLE
Dataset field tooltips

### DIFF
--- a/src/components/ActiveDatasetTab.vue
+++ b/src/components/ActiveDatasetTab.vue
@@ -26,10 +26,18 @@
             <v-col cols="9" class="mr-0">
               <span class="summary-info">{{ summary.id }}</span>
             </v-col>
-            <v-col cols="3" class="pa-4">
-              <v-icon small class="summary-info"
-                >mdi-information-outline</v-icon
+            <v-col v-if="summary.description" cols="3" class="pa-4">
+              <v-tooltip
+                location="bottom"
+                max-width="450px"
+                :text="summary.description"
               >
+                <template v-slot:activator="{ props }">
+                  <v-icon v-bind="props" small class="summary-info, ml-4"
+                    >mdi-information-outline</v-icon
+                  >
+                </template>
+              </v-tooltip>
             </v-col>
           </v-row>
           <v-select

--- a/src/store/map/index.js
+++ b/src/store/map/index.js
@@ -137,10 +137,15 @@ export default {
                   // 4.a add allowedValues and chosenValue to the dataset
                   const summaries =
                     _.get(dataset, "summaries") || _.get(catalog, "summaries");
+                  const summaryDescriptions =
+                    _.get(dataset, "summary_descriptions") ||
+                    _.get(catalog, "summary_descriptions") ||
+                    {};
                   const mappedSummaries = Object.keys(summaries).map((id) => {
                     const summary = _.get(summaries, id);
                     return {
                       id: id,
+                      description: summaryDescriptions[id],
                       allowedValues: summary,
                       chosenValue: summary[0],
                     };


### PR DESCRIPTION
Adds tooltips for the select fields in the active dataset panel. 
Test it by overriding a coclicodata collection, like `slp`:

```json
  "summaries": {
    "scenarios": [
      "high_end",
      "ssp126",
      "ssp245",
      "ssp585"
    ],
    "ensemble": [
      "msl_h",
      "msl_m",
      "msl_l"
    ],
    "time": [
      "2031",
      "2041",
      "2051",
      "2061",
      "2071",
      "2081",
      "2091",
      "2101",
      "2111",
      "2121",
      "2131",
      "2141",
      "2151"
    ]
  },
  "summary_descriptions": {
    "scenarios": "lorem ipsum",
    "ensemble": "lorem ipsum",
    "time": "lorem ipsum"
  },
  ```
 